### PR TITLE
feat: add mailMobileCode and mailMobile fields to V2P request body

### DIFF
--- a/Cardbridge_Changelog.md
+++ b/Cardbridge_Changelog.md
@@ -1,5 +1,10 @@
 ## Change Logs
 
+# 20260611
+__card order__
+
+- POST /open-api/card-order/v1/virtual-to-physical （新增 mailMobileCode、mailMobile 字段，邮寄手机号国家码及手机号，均可选）
+
 # 20260602
 __OTP__
 

--- a/postman/collections/CardBridge OpenAPI.postman_collection.json
+++ b/postman/collections/CardBridge OpenAPI.postman_collection.json
@@ -88,7 +88,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"cardOrderRef\": \"202506201556\",\n    \"replaceCardId\": \"4578334137853731841\",\n    \"virtualToPhysicalInfo\": {\n        \"postalCode\": \"542317\",\n        \"address\": \"307B Anchirvale road\",\n        \"address2\": \"#01-200\",\n        \"address3\": \"Anchirvale Place\",\n        \"address4\": \"Anchirvale Place\",\n        \"address5\": \"Anchirvale Place\",\n        \"countryCode\": \"SG\",\n        \"city\": \"Singapore City\",\n        \"province\": \"Singapore City\",\n        \"embossingName\": \"lee\",\n        \"cardLayoutCode\": \"MGEBP\",\n        \"needShippingInfo\": true\n    }\n}",
+              "raw": "{\n    \"cardOrderRef\": \"202506201556\",\n    \"replaceCardId\": \"4578334137853731841\",\n    \"virtualToPhysicalInfo\": {\n        \"postalCode\": \"542317\",\n        \"address\": \"307B Anchirvale road\",\n        \"address2\": \"#01-200\",\n        \"address3\": \"Anchirvale Place\",\n        \"address4\": \"Anchirvale Place\",\n        \"address5\": \"Anchirvale Place\",\n        \"countryCode\": \"SG\",\n        \"city\": \"Singapore City\",\n        \"province\": \"Singapore City\",\n        \"embossingName\": \"lee\",\n        \"cardLayoutCode\": \"MGEBP\",\n        \"needShippingInfo\": true,\n        \"mailMobileCode\": \"SG\",\n        \"mailMobile\": \"91159519\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
Add two new optional fields to the virtual-to-physical card order endpoint to match the latest CardBridge OpenAPI spec:
- mailMobileCode: 2-letter ISO country code for shipping mobile (e.g. SG)
- mailMobile: shipping mobile number (e.g. 91159519)